### PR TITLE
fix: 修復 story-navigation 組件的 TypeScript 類型錯誤

### DIFF
--- a/components/story-navigation.tsx
+++ b/components/story-navigation.tsx
@@ -3,10 +3,18 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
-import { Book, ShoppingCart, Heart, Search, Home, Library } from 'lucide-react'
+import { Book, ShoppingCart, Heart, Search, Home, Library, LucideIcon } from 'lucide-react'
 import { Input } from '@/components/ui/input'
+import { Route } from 'next'
 
-const navigationItems = [
+interface NavigationItem {
+  href: Route
+  label: string
+  icon: LucideIcon
+  description: string
+}
+
+const navigationItems: NavigationItem[] = [
   { href: '/', label: '首頁', icon: Home, description: '回到故事起點' },
   { href: '/stories', label: '故事世界', icon: Library, description: '探索不同的故事類型' },
   { href: '/products', label: '商品目錄', icon: Book, description: '瀏覽所有商品故事' },


### PR DESCRIPTION
修復 story-navigation.tsx 中的 TypeScript 編譯錯誤

**修復內容:**
- 導入 Route 類型從 Next.js 支援 typedRoutes 功能
- 導入 LucideIcon 類型確保圖標屬性正確類型
- 創建 NavigationItem 介面定義導航項目結構
- 修復 href 屬性類型不匹配的編譯錯誤

**驗證結果:**
✅ Lint 檢查通過
✅ Build 編譯成功

Closes #3

Generated with [Claude Code](https://claude.ai/code)